### PR TITLE
kconfig: allow for using mounted dl and output folders in docker setups

### DIFF
--- a/support/kconfig/confdata.c
+++ b/support/kconfig/confdata.c
@@ -1038,13 +1038,13 @@ int conf_write_autoconf(void)
 	if (!name)
 		name = "include/generated/autoconf.h";
 	sprintf(buf, "%s.tmpconfig.h", dir);
-	if (rename(buf, name))
+	if (file_move(buf, name))
 		return 1;
 	name = getenv("KCONFIG_TRISTATE");
 	if (!name)
 		name = "include/config/tristate.conf";
 	sprintf(buf, "%s.tmpconfig_tristate", dir);
-	if (rename(buf, name))
+	if (file_move(buf, name))
 		return 1;
 	name = conf_get_autoconfig_name();
 	/*
@@ -1052,7 +1052,7 @@ int conf_write_autoconf(void)
 	 * and this marks the successful completion of the previous steps.
 	 */
 	sprintf(buf, "%s.tmpconfig", dir);
-	if (rename(buf, name))
+	if (file_move(buf, name))
 		return 1;
 
 	return 0;

--- a/support/kconfig/lkc.h
+++ b/support/kconfig/lkc.h
@@ -113,6 +113,7 @@ void menu_set_type(int type);
 /* util.c */
 struct file *file_lookup(const char *name);
 int file_write_dep(const char *name);
+int file_move(const char *src, const char *dst);
 void *xmalloc(size_t size);
 void *xcalloc(size_t nmemb, size_t size);
 void *xrealloc(void *p, size_t size);


### PR DESCRIPTION
Kconfig uses C's rename() function, which is not able to e.g. build inside a docker container with a mounted 'dl' and 'output' folder from outside the docker container, so to speak move over "cross-device". 
The approach of the patch is a separate file_move() implementation which does not have the issue and tries to keep the impact as small as possible.

My situation is the following, I'm building inside a docker container, and always try to export 'dl' and 'output' folders, so to use the container only for tooling and a sort of host system installation. I'm doing this with yocto as with buidlroot. Since buildroot is based on kconfig, though, it is (still) not possible to use the docker container as I pretend doing. This small patch would allow for it. Actually I can't tell if this approach is just a dirty hack or useful. 

Please, consider it rather as a proposal. Any feedback is welcome, perhaps I missed something. 